### PR TITLE
feat: add heading font styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Ospray
+
 learning
+
+## Heading Font
+
+Section headings use the `heading-font` utility class, which applies the Merriweather serif font.
+Apply this class to heading elements to style them with the new font.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1 className="heading-font text-3xl">Dashboard</h1>
+      <section>
+        <h2 className="heading-font text-2xl">Section Heading</h2>
+        <p>Content goes here.</p>
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap');
+
+.heading-font {
+  font-family: 'Merriweather', serif;
+}

--- a/src/types/dashboards.ts
+++ b/src/types/dashboards.ts
@@ -1,0 +1,5 @@
+export interface Dashboard {
+  id: string;
+  title: string;
+  metrics: number;
+}


### PR DESCRIPTION
## Summary
- add Merriweather heading-font utility class
- apply heading font to dashboard layout
- document heading font usage and introduce dashboard type

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897abfb77b883278ce6d5d33419cbe7